### PR TITLE
Integrate GPT-4.1-nano for story generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@ This project is a simple web app that shows creative stories about your team's A
 
 ## Features
 - `/admin` page lets you enter context items like projects, students, educators, techniques, and results.
-- `/board` page displays a story that updates every 5 minutes using random combinations of your context items.
+- `/board` page displays a story that updates every 5 minutes using OpenAI's `gpt-4.1-nano` model to combine your context items.
 
 ## Running
 
-1. Install dependencies (FastAPI and Uvicorn are already included in this environment):
+1. Create a virtual environment and install dependencies using [uv](https://github.com/astral-sh/uv):
 
 ```bash
-pip install fastapi uvicorn
+uv venv
+source venv/bin/activate
+uv pip install -r pyproject.toml
 ```
 
 2. Start the server:
@@ -22,5 +24,7 @@ uvicorn main:app --reload --host 0.0.0.0 --port 8000
 
 3. Visit `http://localhost:8000/admin` to add context items.
 4. Open `http://localhost:8000/board` on the big monitor to display stories.
+
+Set your OpenAI API key in the `OPENAI_API_KEY` environment variable before running the app so announcements can be generated using the API.
 
 Stories are generated on demand, so the board will always show something new when it refreshes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "teamstory"
+version = "0.1.0"
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "openai",
+]
+requires-python = ">=3.11"
+


### PR DESCRIPTION
## Summary
- integrate OpenAI API usage with `gpt-4.1-nano`
- add API key configuration
- update README with new instructions
- add `pyproject.toml` and document `uv` usage

## Testing
- `python -m py_compile main.py`
- `uv pip install -r pyproject.toml` *(fails: No route to host)*