### PR TITLE
Add unittest harness and tests

### DIFF
--- a/testharnes.py
+++ b/testharnes.py
@@ -1,0 +1,9 @@
+import unittest
+
+if __name__ == "__main__":
+    loader = unittest.TestLoader()
+    tests = loader.discover("tests")
+    runner = unittest.TextTestRunner()
+    result = runner.run(tests)
+    if not result.wasSuccessful():
+        exit(1)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,61 @@
+import unittest
+from unittest import mock
+import sys
+import types
+
+# Provide a dummy openai module when the real package isn't available.
+if 'openai' not in sys.modules:
+    sys.modules['openai'] = types.SimpleNamespace(
+        ChatCompletion=types.SimpleNamespace(create=lambda *a, **k: None)
+    )
+
+import main
+
+class GenerateStoryTests(unittest.TestCase):
+    def setUp(self):
+        # Keep a copy of the original context
+        self.original_context = {k: list(v) for k, v in main.context.items()}
+        for v in main.context.values():
+            v.clear()
+
+    def tearDown(self):
+        # Restore original context
+        for k in main.context.keys():
+            main.context[k] = list(self.original_context[k])
+
+    def test_no_context(self):
+        story = main.generate_story()
+        self.assertEqual(story, "No stories yet. Add context via /admin.")
+
+    @mock.patch('main.openai.ChatCompletion.create')
+    def test_openai_success(self, mock_create):
+        # Populate minimal context
+        main.context['projects'].append('proj1')
+        main.context['students'].append('stud1')
+        main.context['educators'].append('edu1')
+        main.context['techniques'].append('tech1')
+        main.context['results'].append('res1')
+
+        class FakeChoice:
+            def __init__(self, content):
+                self.message = {"content": content}
+        mock_create.return_value = type('obj', (), {'choices': [FakeChoice('Custom story.')]})
+
+        story = main.generate_story()
+        self.assertEqual(story, 'Custom story.')
+
+    @mock.patch('main.random.choice', side_effect=lambda seq: seq[0])
+    @mock.patch('main.openai.ChatCompletion.create', side_effect=Exception('fail'))
+    def test_openai_failure(self, mock_create, mock_choice):
+        main.context['projects'].append('proj1')
+        main.context['students'].append('stud1')
+        main.context['educators'].append('edu1')
+        main.context['techniques'].append('tech1')
+        main.context['results'].append('res1')
+
+        story = main.generate_story()
+        expected = "stud1 and edu1 are exploring tech1 in proj1, leading to res1."
+        self.assertEqual(story, expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- create testharnes script to run unittests
- add unit tests for `generate_story`

## Testing
- `python testharnes.py`

## Summary by Sourcery

Add a unittest harness and comprehensive unit tests for the generate_story function

New Features:
- Add testharnes.py script to discover and run all tests

Enhancements:
- Provide a dummy openai module to prevent import errors
- Isolate and restore main.context state between tests using setUp/tearDown

Tests:
- Add tests for generate_story with no context, successful OpenAI response, and fallback story generation on OpenAI failure