### PR TITLE
Add Docker container and CI pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__
+*.pyc
+.git
+tests
+*.env
+venv
+uv.lock
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install uv
+      - run: uv pip install -r pyproject.toml
+      - run: python testharnes.py
+
+  docker:
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+WORKDIR /app
+
+# Install uv and project dependencies
+RUN pip install uv
+
+COPY pyproject.toml ./
+RUN uv pip install -r pyproject.toml
+
+# Copy source
+COPY . .
+
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -28,3 +28,17 @@ uvicorn main:app --reload --host 0.0.0.0 --port 8000
 Set your OpenAI API key in the `OPENAI_API_KEY` environment variable before running the app so announcements can be generated using the API.
 
 Stories are generated on demand, so the board will always show something new when it refreshes.
+
+## Docker
+
+You can run the application in a container:
+
+```bash
+docker build -t teamstory .
+docker run -p 8000:8000 -e OPENAI_API_KEY=your-key teamstory
+```
+The Dockerfile installs [uv](https://github.com/astral-sh/uv) and uses it to install the dependencies listed in `pyproject.toml`.
+
+## Continuous Integration
+
+A GitHub Actions workflow installs uv, installs dependencies with `uv pip install -r pyproject.toml`, runs the unit tests and, when changes are pushed to `main`, builds and publishes a Docker image to the GitHub Container Registry.


### PR DESCRIPTION
## Summary
- containerize the app with a new `Dockerfile`
- ignore development files in `.dockerignore`
- document Docker usage and CI/CD in `README`
- add a GitHub Actions workflow to test and publish images
- switch Docker and CI to install deps with `uv`

## Testing
- `python testharnes.py`

## Summary by Sourcery

Containerize the application with Docker, switch to uv for dependency management, set up a GitHub Actions CI pipeline for testing and image publishing, and update documentation accordingly

New Features:
- Add Docker-based containerization for the application

Enhancements:
- Switch dependency installation to use uv in Docker and CI workflows

Build:
- Add Dockerfile and .dockerignore for container builds

CI:
- Introduce GitHub Actions workflow to test the application and publish Docker images on pushes to main

Documentation:
- Document Docker usage and CI/CD process in the README