### PR TITLE
Fix Docker build with uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           python-version: '3.11'
       - run: pip install uv
-      - run: uv pip install -r pyproject.toml
+      - run: uv pip install --system -r pyproject.toml
       - run: python testharnes.py
 
   docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN pip install uv
 
 COPY pyproject.toml ./
-RUN uv pip install -r pyproject.toml
+RUN uv pip install --system -r pyproject.toml
 
 # Copy source
 COPY . .


### PR DESCRIPTION
## Summary
- install dependencies using the system environment when building the Docker image

## Testing
- `python testharnes.py`

## Summary by Sourcery

Bug Fixes:
- Add --system flag to `uv pip install -r pyproject.toml` in both the CI workflow and Dockerfile to ensure dependencies are installed in the system environment.